### PR TITLE
fail build when dmg creation returns error

### DIFF
--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/DmgGenerator.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/DmgGenerator.java
@@ -51,6 +51,7 @@ public class DmgGenerator {
     private DmgConfiguration getDmgConfiguration() {
         return this.dmgConfiguration;
     }
+
     private void setDmgConfiguration(DmgConfiguration dmgConfiguration) {
         this.dmgConfiguration = dmgConfiguration;
     }
@@ -58,6 +59,7 @@ public class DmgGenerator {
     private Log getLog() {
         return this.log;
     }
+
     private void setLog(Log log) {
         this.log = log;
     }
@@ -106,7 +108,10 @@ public class DmgGenerator {
             dmgCommandLine.createArg().setValue(dmgFile.getAbsolutePath());
             dmgCommandLine.createArg().setValue("-volname");
             dmgCommandLine.createArg().setValue(this.getVolumeName());
-            dmgCommandLine.execute().waitFor();
+            int returnValue = dmgCommandLine.execute().waitFor();
+            if (returnValue != 0) {
+                throw new Exception("Command 'hdiutil' exited with status " + returnValue);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Cannot generate DMG archive at: " + dmgFile.getAbsolutePath(), e);
         }
@@ -136,6 +141,7 @@ public class DmgGenerator {
     private String getVolumeName() {
         return this.volumeName;
     }
+
     private void setVolumeName(String volumeName) {
         this.volumeName = volumeName;
     }


### PR DESCRIPTION
Hi,

this PR adds the ability to fail the build when the `hdiutil` command returns != 0. 

This is useful when there is either an error with the tool or it's not available (for example when building on systems other than macOS). In case of the command not being available, 127 is returned.

A workaround for still having the build work without `hdiutil` would be creating an extra configuration in a profile which is run only on macOS.