### PR TITLE
Add ability to use `genisoimage` instead of `hdiutil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The following other properties can be added to the `dmg` element configuring the
 | `generate` | Boolean | No | `false` | Whether or not to create a `DMG` file. |
 | `additionalResources` | List<Fileset> | No | | Additional files to be copied into the archive. |
 | `createApplicationsSymlink` | Boolean | No | `true` | Whether or not to include a link to the Applications folder inside the archive. |
+| `useGenIsoImage` | Boolean | No | `false` | Whether or not to use `genisoimage` to create the archive. Default is `hdiutil`. |
+| `autoFallback` | Boolean | No | `false` | If `true`, try the other archive generation method when the first one fails. (e.g. run `hdiutil` when `genisoimage` fails and vice-versa) |
 
 ## Development
 

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/DmgConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/DmgConfiguration.java
@@ -32,4 +32,10 @@ public class DmgConfiguration {
     @Parameter
     public boolean createApplicationsSymlink = true;
 
+    @Parameter
+    public boolean useGenIsoImage = false;
+
+    @Parameter
+    public boolean autoFallback = false;
+
 }


### PR DESCRIPTION
Hi, 
as mentioned in #1, this PR adds the ability to use `genisoimage` instead of `hdiutil`. This can be done by using the `useGenIsoImage` configuration option.

Additionally, there now is the `autoFallback` option which tries to use the other method automatically if the one selected (by setting `useGenIsoImage`) returns `!= 0`. This might be useful for teams using different operating systems (or CI, etc.).