### PR TITLE
[Fixes #5] Add two new config options: appendVersion and dmgFileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Maven plugin for creating a native [macOS bundle](https://developer.apple.com/li
     <plugin>
         <groupId>de.perdian.maven.plugins</groupId>
         <artifactId>macosappbundler-maven-plugin</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <configuration>
             <plist>
                 <JVMMainClassName>de.perdian.test.YourApplication</JVMMainClassName>
@@ -39,7 +39,7 @@ Maven plugin for creating a native [macOS bundle](https://developer.apple.com/li
     <plugin>
         <groupId>de.perdian.maven.plugins</groupId>
         <artifactId>macosappbundler-maven-plugin</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <configuration>
             <plist>
                 <CFBundleIconFile>src/bundle/test.icns</CFBundleIconFile>
@@ -119,6 +119,8 @@ The following other properties can be added to the `dmg` element configuring the
 | `createApplicationsSymlink` | Boolean | No | `true` | Whether or not to include a link to the Applications folder inside the archive. |
 | `useGenIsoImage` | Boolean | No | `false` | Whether or not to use `genisoimage` to create the archive. Default is `hdiutil`. |
 | `autoFallback` | Boolean | No | `false` | If `true`, try the other archive generation method when the first one fails. (e.g. run `hdiutil` when `genisoimage` fails and vice-versa) |
+| `appendVersion` | Boolean | No | `true` | If `true`, append version to `.dmg` name
+| `dmgFileName` | String | No | `null` | If not `null` or empty, the supplied string will be used as the name (`.dmg` will be appended).
 
 ## Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.perdian.maven.plugins</groupId>
     <artifactId>macosappbundler-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <name>macOS app bundler Maven plugin</name>
     <description>Maven plugin to create a macOS application bundle</description>
@@ -99,7 +99,7 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>file-management</artifactId>
             <version>${file-management.version}</version>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -159,7 +159,7 @@
                         </executions>
                         <configuration>
                             <source>8</source>
-                        </configuration> 
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.kohsuke</groupId>

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/BundleMojo.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/BundleMojo.java
@@ -74,7 +74,15 @@ public class BundleMojo extends AbstractMojo {
 
             if (this.dmg.generate) {
                 File bundleDirectory = new File(targetDirectory, "bundle");
-                File dmgFile = new File(targetDirectory, appName + ".dmg");
+                String dmgFileName;
+                if (this.dmg.appendVersion) {
+                    dmgFileName = appName + "_" + this.project.getVersion() + ".dmg";
+                } else if (this.dmg.dmgFileName == null || this.dmg.dmgFileName.isEmpty()) {
+                    dmgFileName = appName + ".dmg";
+                } else {
+                    dmgFileName = this.dmg.dmgFileName + ".dmg";
+                }
+                File dmgFile = new File(targetDirectory, dmgFileName);
                 DmgGenerator dmgGenerator = new DmgGenerator(this.dmg, appName, this.getLog());
                 dmgGenerator.generateDmg(this.project, appDirectory, bundleDirectory, dmgFile);
             }

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/DmgConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/DmgConfiguration.java
@@ -38,4 +38,10 @@ public class DmgConfiguration {
     @Parameter
     public boolean autoFallback = false;
 
+    @Parameter
+    public boolean appendVersion = true;
+
+    @Parameter
+    public String dmgFileName = null;
+
 }


### PR DESCRIPTION
Hi,
this PR adds two new config options: 
- `appendVersion` to add the program version to the `.dmg` file
- `dmgFileName` uses the supplied value as name and appends `.dmg`

If `dmgFileName` is `null` (default) or empty, and `appendVersion` is `true`, the name will be `application_1.0-SNAPSHOT.dmg`, if `dmgFileName` is set to `foobar`, the file name will be `foobar.dmg`; `appendVersion` is ignored if a custom name is used. 

This change affects both, `hdiutil` and `genisoimage`.

This was done to fix #5 while keeping flexible with naming.