### PR TITLE
Added support for NSHighResolutionCapable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following values can be configured:
 | `JVMArguments` | Array of Strings | No | | Additional arguments to be passed to the runtime. |
 | `JVMRuntimePath` | String | No | | The exact location of the JVM. |
 | `JVMLogLevel` | String | No | `INFO` | The amount of details the launcher will print to the console if called directly from the command line. Possible values: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`. |
+| `NSHighResolutionCapable` | Boolean | No | | Declares if the application supports rendering in HiDPI (Retina).
 
 ### DMG configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.perdian.maven.plugins</groupId>
     <artifactId>macosappbundler-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.1</version>
 
     <name>macOS app bundler Maven plugin</name>
     <description>Maven plugin to create a macOS application bundle</description>

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
@@ -16,9 +16,10 @@
  */
 package de.perdian.maven.plugins.macosappbundler.mojo.model;
 
-import java.io.StringWriter;
-import java.util.List;
-import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -27,11 +28,9 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
 
 public class PlistConfiguration {
 
@@ -74,6 +73,9 @@ public class PlistConfiguration {
     @Parameter
     public String JVMLogLevel = null;
 
+    @Parameter
+    public Boolean NSHighResolutionCapable = null;
+
     public String toXmlString(Map<String, String> additionalValues) throws Exception {
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
@@ -107,6 +109,7 @@ public class PlistConfiguration {
         this.appendKeyWithString(dictElement, document, "JVMRuntimePath", this.JVMRuntimePath);
         this.appendKeyWithString(dictElement, document, "JVMVersion", this.JVMVersion);
         this.appendKeyWithString(dictElement, document, "JVMLogLevel", this.JVMLogLevel);
+        this.appendKeyWithString(dictElement, document, "NSHighResolutionCapable", this.NSHighResolutionCapable.toString());
         for (Map.Entry<String, String> additionalValue : additionalValues.entrySet()) {
             this.appendKeyWithString(dictElement, document, additionalValue.getKey(), additionalValue.getValue());
         }


### PR DESCRIPTION
Hi!
This PR adds the ability to configure the property NSHighResolutionCapable in the Info.plist to support HiDPI (Retina) displays. If this property is missing in the Info.plist the application will be scaled up and appears blurry on HiDPI displays.