### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/compile-native-executable.sh
+++ b/compile-native-executable.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 EXECUTABLE_FILE=target/classes/${EXECUTABLE_FILE_NAME:-JavaLauncher}
 INPUT_FILES=$(find src/main/native -name "*.m")
 INCLUDE_JAVA=$(/usr/libexec/java_home)/include
@@ -8,12 +12,27 @@ SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Dev
 
 mkdir -p $(dirname $EXECUTABLE_FILE)
 
-echo "Compiling executable into: $(realpath $EXECUTABLE_FILE)"
+echo "Compiling x86_64 executable into: $(realpath $EXECUTABLE_FILE).x86_64"
 clang \
   -I ${INCLUDE_JAVA} \
   -I ${INCLUDE_JAVA_DARWIN} \
   -isysroot ${SYSROOT} \
   -framework Cocoa \
   -mmacosx-version-min=10.12 \
-  -o ${EXECUTABLE_FILE} \
+  -target x86_64-apple-darwin-macho \
+  -o "${EXECUTABLE_FILE}.x86_64" \
   ${INPUT_FILES}
+
+echo "Compiling arm64 executable into: $(realpath $EXECUTABLE_FILE).arm64"
+clang \
+  -I ${INCLUDE_JAVA} \
+  -I ${INCLUDE_JAVA_DARWIN} \
+  -isysroot ${SYSROOT} \
+  -framework Cocoa \
+  -mmacosx-version-min=10.12 \
+  -target arm64-apple-darwin-macho \
+  -o "${EXECUTABLE_FILE}.arm64" \
+  ${INPUT_FILES}
+
+echo "Generating universal executable into: $(realpath $EXECUTABLE_FILE)"
+lipo -create -output ${EXECUTABLE_FILE} "${EXECUTABLE_FILE}.x86_64" "${EXECUTABLE_FILE}.arm64"


### PR DESCRIPTION
Hi,

this PR adds support for Apple Silicon by compiling both architectures and merging those by using [the lipo tool](https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary#3618377).

This only works with macOS >=11.0.1 (and clang >=12) so this might require increasing the minimum required macOS version **but** I can't test this because I don't have an older version of macOS to execute the universal executable on 🤦
