### PR TITLE
Enable apps to run on the internal GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The following values can be configured:
 | `JVMLogLevel` | String | No | `INFO` | The amount of details the launcher will print to the console if called directly from the command line. Possible values: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`. |
 | `NSHighResolutionCapable` | Boolean | No | `true` | Declares if the application supports rendering in HiDPI (Retina). [Details](https://developer.apple.com/documentation/bundleresources/information_property_list/nshighresolutioncapable) |
 | `LSUIElement` | Boolean | No | | Declares if the app is an agent app that runs in the background and doesn't appear in the Dock. [Details](https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement) |
+| `NSSupportsAutomaticGraphicsSwitching` | Boolean | No | `true` | Declares whether an OpenGL app may utilize the integrated GPU. [Details](https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching) |
 
 ### DMG configuration
 

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
@@ -17,9 +17,10 @@
  */
 package de.perdian.maven.plugins.macosappbundler.mojo.model;
 
-import java.io.StringWriter;
-import java.util.List;
-import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,11 +29,9 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
 
 public class PlistConfiguration {
 
@@ -87,6 +86,9 @@ public class PlistConfiguration {
     @Parameter
     public Boolean LSUIElement = null;
 
+    @Parameter
+    public Boolean NSSupportsAutomaticGraphicsSwitching = Boolean.TRUE;
+
     public String toXmlString(Map<String, String> additionalValues) throws Exception {
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
@@ -124,6 +126,7 @@ public class PlistConfiguration {
         this.appendKeyWithString(dictElement, document, "JVMLogLevel", this.JVMLogLevel);
         this.appendKeyWithBoolean(dictElement, document, "NSHighResolutionCapable", this.NSHighResolutionCapable);
         this.appendKeyWithBoolean(dictElement, document, "LSUIElement", this.LSUIElement);
+        this.appendKeyWithBoolean(dictElement, document, "NSSupportsAutomaticGraphicsSwitching", this.NSSupportsAutomaticGraphicsSwitching);
         for (Map.Entry<String, String> additionalValue : additionalValues.entrySet()) {
             this.appendKeyWithString(dictElement, document, additionalValue.getKey(), additionalValue.getValue());
         }

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/PlistConfiguration.java
@@ -17,10 +17,9 @@
  */
 package de.perdian.maven.plugins.macosappbundler.mojo.model;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -29,9 +28,11 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.StringWriter;
-import java.util.List;
-import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 public class PlistConfiguration {
 


### PR DESCRIPTION
Added additional property NSSupportsAutomaticGraphicsSwitching to enable apps running on the internal GPU.
See: https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching