### PR TITLE
name for jre folder (its not a jdk)

### DIFF
--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/AppGenerator.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/AppGenerator.java
@@ -65,7 +65,7 @@ public class AppGenerator {
 
     public void generateApp(MavenProject project, File appDirectory) throws MojoExecutionException {
         this.copyApplicationClasses(project, new File(appDirectory, "Contents/Java"));
-        this.copyJdk(new File(appDirectory, "Contents/Java/jdk"));
+        this.copyJdk(new File(appDirectory, "Contents/Java/Runtime.jre"));
         this.copyNativeExecutable(new File(appDirectory, "Contents/MacOS"));
         this.generatePlist(project, new File(appDirectory, "Contents/"));
 

--- a/src/main/native/helpers/jvm_resolver.m
+++ b/src/main/native/helpers/jvm_resolver.m
@@ -73,7 +73,7 @@
     }
     NSBundle *applicationBundle = [NSBundle mainBundle];
     NSString *applicationDirectory = [applicationBundle bundlePath];
-    NSString *jdkDataDirectory = [applicationDirectory stringByAppendingPathComponent:@"Contents/Java/jdk"];
+    NSString *jdkDataDirectory = [applicationDirectory stringByAppendingPathComponent:@"Contents/Java/Runtime.jre"];
     if ([[NSFileManager defaultManager] fileExistsAtPath:jdkDataDirectory isDirectory:NULL]) {
         log_info(@"Using internally provided JDK at: %@", jdkDataDirectory);
         return jdkDataDirectory;


### PR DESCRIPTION
PR proposes to rename the folder the private JRE is placed. Currently its called jdk. Usually only JRE will be distributed. This PR renames the folder to Runtime.jre