### PR TITLE
Add primaryArtifactClassifier attribute to the AppConfiguration

### DIFF
--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/AppGenerator.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/impl/AppGenerator.java
@@ -101,7 +101,14 @@ public class AppGenerator {
 
     private void copyClasspathApplicationClasses(MavenProject project, File classpathDirectory) throws IOException {
         ArtifactRepositoryLayout repositoryLayout = new DefaultRepositoryLayout();
-        this.copyClasspathApplicationDependencyArtifact(project.getArtifact(), classpathDirectory, repositoryLayout);
+        String classifier = this.getAppConfiguration().getPrimaryArtifactClassifier();
+    	Artifact primaryArtifact = null;
+    	if (classifier != null && !classifier.isEmpty())  for (Artifact attachedArtifact : project.getAttachedArtifacts()) {
+            if (classifier.equals(attachedArtifact.getClassifier())) primaryArtifact = attachedArtifact;
+        }
+    	if (primaryArtifact == null) primaryArtifact = project.getArtifact();
+        
+        this.copyClasspathApplicationDependencyArtifact(primaryArtifact, classpathDirectory, repositoryLayout);
         if (this.getAppConfiguration().isIncludeDependencies()) {
             for (Artifact artifact : project.getArtifacts()) {
                 this.copyClasspathApplicationDependencyArtifact(artifact, classpathDirectory, repositoryLayout);
@@ -120,7 +127,14 @@ public class AppGenerator {
     }
 
     private void copyModulesApplicationClasses(MavenProject project, File modulesDirectory) throws IOException {
-        this.copyModulesApplicationClassesArtifact(project.getArtifact(), modulesDirectory);
+        String classifier = this.getAppConfiguration().getPrimaryArtifactClassifier();
+    	Artifact primaryArtifact = null;
+    	if (classifier != null && !classifier.isEmpty())  for (Artifact attachedArtifact : project.getAttachedArtifacts()) {
+            if (classifier.equals(attachedArtifact.getClassifier())) primaryArtifact = attachedArtifact;
+        }
+    	if (primaryArtifact == null) primaryArtifact = project.getArtifact();
+    	this.copyModulesApplicationClassesArtifact(primaryArtifact, modulesDirectory);
+    	
         if (this.getAppConfiguration().isIncludeDependencies()) {
             for (Artifact artifact : project.getArtifacts()) {
                 this.copyModulesApplicationClassesArtifact(artifact, modulesDirectory);
@@ -134,6 +148,8 @@ public class AppGenerator {
         StringBuilder targetFileName = new StringBuilder();
         targetFileName.append(artifact.getArtifactId());
         targetFileName.append("-").append(artifact.getVersion());
+        String classifier = artifact.getClassifier();
+        if (classifier != null && !classifier.isEmpty()) targetFileName.append("-").append(classifier);
         targetFileName.append(".").append(FilenameUtils.getExtension(artifact.getFile().getName()));
         File targetFile = new File(modulesDirectory, targetFileName.toString());
         if (!targetFile.getParentFile().exists()) {

--- a/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/AppConfiguration.java
+++ b/src/main/java/de/perdian/maven/plugins/macosappbundler/mojo/model/AppConfiguration.java
@@ -28,6 +28,9 @@ public class AppConfiguration {
 
     @Parameter
     public boolean includeDependencies = true;
+    
+    @Parameter
+    public String primaryArtifactClassifier;
 
     public boolean isIncludeDependencies() {
         return this.includeDependencies;
@@ -35,6 +38,12 @@ public class AppConfiguration {
     public void setIncludeDependencies(boolean includeDependencies) {
         this.includeDependencies = includeDependencies;
     }
-
+    
+    public String getPrimaryArtifactClassifier() {
+		return this.primaryArtifactClassifier;
+	}
+	public void setPrimaryArtifactClassifier(String primaryArtifactClassifier) {
+		this.primaryArtifactClassifier = primaryArtifactClassifier;
+	}
 
 }


### PR DESCRIPTION
If specified, copy the artifact with a specified classifier in copy Classpath/Modules ApplicationClasses. Often, you attach secondary artifacts with additional classifiers to the module, e.g. an obfuscated version that you want to bundle to your app.